### PR TITLE
Fix password encryption params

### DIFF
--- a/Encrypt/FileDecryptor.swift
+++ b/Encrypt/FileDecryptor.swift
@@ -31,8 +31,8 @@ class FileDecryptor {
         let aesKey: SymmetricKey
 
         if type == "password" {
-            guard let saltBase64 = json["salt_user"] as? String,
-                  let salt = Data(base64Encoded: saltBase64),
+            guard let saltHex = json["salt_user"] as? String,
+                  let salt = Data(hex: saltHex),
                   let password = password else {
                 throw NSError(domain: "Faltan datos de contraseña", code: 2)
             }

--- a/Encrypt/SheetFormularioCifrado.swift
+++ b/Encrypt/SheetFormularioCifrado.swift
@@ -264,12 +264,6 @@ struct SheetFormularioCifrado: View {
             ]
             
             if usarContraseña {
-                let saltUser = Data((0..<16).map { _ in UInt8.random(in: 0...255) })
-                let saltAdmin = Data((0..<16).map { _ in UInt8.random(in: 0...255) })
-                let ivUser = Data((0..<16).map { _ in UInt8.random(in: 0...255) })
-                let ivAdmin = Data((0..<16).map { _ in UInt8.random(in: 0...255) })
-                
-                let keyUser = CryptoUtils.deriveKey(from: contraseña, salt: saltUser)
                 let keyAdmin = CryptoUtils.deriveKey(from: "SeguraAdmin123", salt: saltAdmin)
                 guard let encryptedPassword = CryptoUtils.encryptCBC(
                     data: contraseña.data(using: .utf8)!,
@@ -281,12 +275,10 @@ struct SheetFormularioCifrado: View {
                 }
                 json["encrypted_user_password"] = encryptedPassword.toHexString()
 
-                
                 json["salt_user"] = saltUser.toHexString()
                 json["salt_admin"] = saltAdmin.toHexString()
                 json["iv_user"] = ivUser.toHexString()
                 json["iv_admin"] = ivAdmin.toHexString()
-                json["encrypted_user_password"] = encryptedPassword.toHexString()
                 
             } else {
                 guard let llave = llaveSeleccionada else {


### PR DESCRIPTION
## Summary
- keep consistent salts/IVs when encrypting with password
- parse salt data stored in hex during decryption

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68794757b56c8328a0f862c77e7d8e89